### PR TITLE
add FfmpegMediaTypeError

### DIFF
--- a/src/ffmpeg_media_type/exceptions.py
+++ b/src/ffmpeg_media_type/exceptions.py
@@ -1,0 +1,2 @@
+class FfmpegMediaTypeError(Exception):
+    pass

--- a/src/ffmpeg_media_type/utils/shell.py
+++ b/src/ffmpeg_media_type/utils/shell.py
@@ -2,6 +2,8 @@ import os
 import shlex
 import tempfile
 
+from ..exceptions import FfmpegMediaTypeError
+
 
 def call(cmds: list[str]) -> str:
     # call command and return stdout
@@ -9,7 +11,8 @@ def call(cmds: list[str]) -> str:
     command = " ".join(shlex.quote(part) for part in cmds)
     with tempfile.TemporaryDirectory() as tmpdir:
         output_path = f"{tmpdir}/output.txt"
-        assert os.system(f"{command} > {output_path}") == 0, f"command failed: {command}"
+        if os.system(f"{command} > {output_path}") != 0:
+            raise FfmpegMediaTypeError(f"command failed: {command}")
 
         with open(output_path) as ifile:
             return ifile.read()


### PR DESCRIPTION
Fixes #36 

raise FfmpegMediaTypeError for now, but more precise error message (eg. stderr) should be considered in the future.