### PR TITLE
fix(docs): rename mkdocstrings-python option 'order' to 'members_order'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,7 @@ plugins:
             signature_crossrefs: true
             summary: true
             docstring_section_style: table
-            order: source
+            members_order: source
             docstring_style: google
             extensions:
               - griffe_inherited_docstrings


### PR DESCRIPTION
## Summary

Fixes a mkdocs Build failure in CI: the mkdocstrings-python handler does not recognize a top-level \`order\` option and raises:

> Invalid options: PythonOptions.\_\_init\_\_() got an unexpected keyword argument 'order'

The correct option name for sort order in mkdocstrings-python is \`members_order\`. This rename restores the docs build.

## Changes

- \`mkdocs.yml:106\`: \`order: source\` → \`members_order: source\`

## Test plan

- [ ] CI \`Build Mkdocs\` step passes on this PR
- [ ] PR #757 (prek migration) CI passes after this is merged + rebased